### PR TITLE
[Fix] --concurrency로 프로세스 수 조절하기

### DIFF
--- a/backend_django/docker-compose.prod.yml
+++ b/backend_django/docker-compose.prod.yml
@@ -124,7 +124,7 @@ services:
   backend-celery-worker:
     build: .
     container_name: backend-celery-worker
-    command: sh -c "uv pip install --system --no-cache-dir -r requirements.txt && celery -A config worker -l info --concurrency=4"
+    command: sh -c "uv pip install --system --no-cache-dir -r requirements.txt && celery -A config worker -l info --concurrency=1"
     volumes:
       - .:/backend
       # - ./gcp-key.json:/app/gcp-key.json # GCP 키 파일 마운트 (비활성화)


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#11 

## 📝작업 내용
docker-compose.prod.yml에서 --concurrency 설정을 변경했습니다.
배포 서버에서 저 설정을 바꾸어가며 부하테스트를 진행하고, 프로세스 수가 몇 개일때 최적인지 알아보겠습니다. 
해당 PR은 최적의 프로세스 수를 찾을 경우 merge합니다.